### PR TITLE
Hotfix: Don't remove the hunger from the pool

### DIFF
--- a/script.js
+++ b/script.js
@@ -33,9 +33,6 @@ let app = new Vue({
             //Use only hunger dice, when the pool is larger than the hunger. Otherwise subtract hunger from pool to replace it
             if(hunger >= pool) {
                 hunger = pool;
-                pool = 0;
-            } else {
-                pool = pool - hunger;
             }
 
             //If the number of needed successes is active, use it or set it zero otherwise


### PR DESCRIPTION
# Description
Until now, the hunger points were substracted from the main dice pool. The bot on the other hand doesn't do this, which results in a dicepool which is too small.

# Test
1. Put
    - Stat 1: 2
    - Stat 2: 1
    - Hunger: 1
2. The command should now be: `m.r5 3 1 0`